### PR TITLE
Standalone Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ for instance xDAI, with support for those namespaces *are* supported, as long as
 
 ### ERC721:
 
-```
+```gql
 type Token @entity {
   id: ID!
   contract: TokenContract!
@@ -100,7 +100,7 @@ type Owner @entity {
 ```
 
 ### ERC1155:
-```
+```gql
 type Account @entity {
   id: ID!
   balances: [Balance!]! @derivedFrom(field: "account")

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@ceramicnetwork/blockchain-utils-linking": "^0.3.0",
         "@ceramicnetwork/core": "^0.21.0",
         "@ceramicnetwork/http-client": "^0.10.1",
+        "@types/jest": "^26.0.22",
         "@types/node": "^13.13.15",
         "@typescript-eslint/eslint-plugin": "^4.6.0",
         "@typescript-eslint/parser": "^4.6.0",
@@ -3415,6 +3416,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "26.0.22",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.22.tgz",
+      "integrity": "sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==",
+      "dev": true,
+      "dependencies": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -31187,6 +31198,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "26.0.22",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.22.tgz",
+      "integrity": "sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
       }
     },
     "@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@ceramicnetwork/blockchain-utils-linking": "^0.3.0",
     "@ceramicnetwork/core": "^0.21.0",
     "@ceramicnetwork/http-client": "^0.10.1",
+    "@types/jest": "^26.0.22",
     "@types/node": "^13.13.15",
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -115,7 +115,6 @@ describe('NFT DID Resolver (TheGraph)', () => {
     });
 
     it('throws when the caip2 chainId is malformed', () => {
-      const badUrl = 'http: //api.thegraph.com/subgraphs/name/wighawag/eip721-subgraph';
       const customConfig = {
         ceramic: ceramic,
         subGraphUrls: {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -250,7 +250,7 @@ describe('NFT DID Resolver (TheGraph)', () => {
         .build();
 
       await expectVectorResult(customResolver, nftVector);
-      expect(fetch.mock.calls[0][0]).toEqual(custom721Subgraph);
+      expect(fetchMock.mock.calls[0][0]).toEqual(custom721Subgraph);
     });
 
     it('allows for erc721 namespace on caip2 chains beside eth', async () => {
@@ -390,7 +390,7 @@ describe('NFT DID Resolver (TheGraph)', () => {
         .build();
 
       await expectVectorResult(customResolver, nftVector);
-      expect(fetch.mock.calls[0][0]).toEqual(custom1155Subgraph);
+      expect(fetchMock.mock.calls[0][0]).toEqual(custom1155Subgraph);
     });
 
     it('allows for erc1155 namespace on caip2 chains beside eth', async () => {
@@ -434,13 +434,17 @@ const isoTimeToTimestamp = (versionTime: string) => {
 function expectBlockQueries(versionTime: string) {
   // Note: For each indexed call, the 0th elem is the url, and the 1st elem is what was sent to fetch
   // the first call will be to query the block at timestamp
-  expect(fetch.mock.calls[0][0]).toEqual(BLOCK_QUERY_URL);
+  expect(fetchMock.mock.calls[0][0]).toEqual(BLOCK_QUERY_URL);
 
   // check that the call includes the timestamp
-  expect(fetch.mock.calls[0][1].body.includes(`timestamp_lte: ${isoTimeToTimestamp(versionTime)}`)).toBe(true);
+  expect(fetchMock.mock.calls[0][1].body.toString()
+    .includes(`timestamp_lte: ${isoTimeToTimestamp(versionTime)}`))
+    .toBe(true);
 
   // check that the call to the NFT subgraph includes the mocked block number
-  expect(fetch.mock.calls[1][1].body.includes(`number: ${blockQueryNumber}`)).toBe(true);
+  expect(fetchMock.mock.calls[1][1].body.toString()
+    .includes(`number: ${blockQueryNumber}`))
+    .toBe(true);
 }
 
 async function createCaip10Link(ethAuthProv: EthereumAuthProvider) {

--- a/src/testUtils/NftDidVector.ts
+++ b/src/testUtils/NftDidVector.ts
@@ -1,9 +1,9 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { DIDResolutionResult, VerificationMethod } from "did-resolver";
-
 export class NftDidVector {
   nftDid: string;
-  nftOwners: string[];
-  verificationMethods: VerificationMethod[];
+  nftOwners: string[] | undefined;
+  verificationMethods: VerificationMethod[] | undefined;
   versionId: string | undefined;
   versionTime: string | undefined;
   caip10Controller: string | undefined;
@@ -45,12 +45,14 @@ export class NftDidVector {
     const resolutionResult = {
       didDocument: {
         id: this.nftDid,
-        verificationMethod: [...this.verificationMethods]
       },
       didDocumentMetadata: {},
       didResolutionMetadata: { contentType: 'application/did+json' }
     } as DIDResolutionResult;
 
+    // @ts-ignore: Object is possibly 'null'
+    if (this.verificationMethods) resolutionResult.didDocument.verificationMethod = [...this.verificationMethods];
+    // @ts-ignore: Object is possibly 'null'
     if (this.caip10Controller) resolutionResult.didDocument.controller = this.caip10Controller;
     return resolutionResult;
   }
@@ -61,12 +63,12 @@ export class NftDidVectorBuilder {
   public readonly nftNamespace: string;
   public readonly caip2ChainId: string;
 
-  public nftContract: string;
-  public nftId: string;
-  public nftDid: string;
-  public nftOwners: string[];
+  public nftDid = ''; // falsey, will throw if not made or provided
+  public nftContract: string | undefined;
+  public nftId: string | undefined;
+  public nftOwners: string[] | undefined;
 
-  public verificationMethods: VerificationMethod[];
+  public verificationMethods: VerificationMethod[] | undefined;
   public versionId: string | undefined;
   public versionTime: string | undefined;
   public caip10Controller: string | undefined;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,15 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "ES2018",
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+  ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
     "rootDir": "src",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true
   },
   "include": ["./src/**/*"],
   "exclude": [


### PR DESCRIPTION
- Allow the resolver to be built as a standalone package, rather than as a component of the `js-ceramic` monorepo by updating the tsconfig.
- Use `toString` on the body of call requests in tests so they are happy.

- Add `gql` to the comment blocks for the graphql schemas so that they look prettier.

- Enforce `strict`, `noUnusedLocals`, and `noImplicitReturns` in tsconfig