### PR TITLE
feat: change id in verification method to account address

### DIFF
--- a/src/__tests__/nft-did-vector.ts
+++ b/src/__tests__/nft-did-vector.ts
@@ -150,7 +150,7 @@ export class NftDidVectorBuilder {
 
     return this.nftOwners.slice().map((owner) => {
       return {
-        id: `${this.nftDid}#owner`,
+        id: `${this.nftDid}#${owner}`,
         type: 'BlockchainVerificationMethod2021',
         controller: this.nftDid,
         blockchainAccountId: `${owner}@${this.caip2ChainId}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ function wrapDocument(did: string, accounts: AccountID[], controllers?: string[]
   // Each of the owning accounts is a verification method (at the point in time)
   const verificationMethods = accounts.slice().map((account) => {
     return {
-      id: `${did}#owner`,
+      id: `${did}#${account.address}`,
       type: 'BlockchainVerificationMethod2021',
       controller: did,
       blockchainAccountId: account.toString(),


### PR DESCRIPTION
Having #owner id for multiple verificationMethods can be problematic as it is designed to be unique identifier.