### PR TITLE
chore: Bump caip from beta to GA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ceramicnetwork/common": "^1.1.0",
         "@ceramicnetwork/stream-caip10-link": "^1.0.7",
         "bignumber.js": "^9.0.1",
-        "caip": "1.0.0-beta.0",
+        "caip": "^1.0.0",
         "cross-fetch": "^3.1.4",
         "json-to-graphql-query": "^2.1.0",
         "merge-options": "^3.0.4",
@@ -6554,9 +6554,9 @@
       }
     },
     "node_modules/caip": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/caip/-/caip-1.0.0-beta.0.tgz",
-      "integrity": "sha512-bjJDXitV6qV9az8ybeCMLOAgkrktinx7O5vlmk/0z0c4P8YjW/bxMwPvkytuRlWG5zNQd4IRYMEq7Gr9k3rQVA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/caip/-/caip-1.0.0.tgz",
+      "integrity": "sha512-+U9P7+9jeVBWoP7BDWHVD/JGp9azT4KmFCpDRKTy0U01bCV0x7bxwf6WTl0/dUnnTE+ZA9M4EavptQdHg7k1vA=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -35598,9 +35598,9 @@
       "dev": true
     },
     "caip": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/caip/-/caip-1.0.0-beta.0.tgz",
-      "integrity": "sha512-bjJDXitV6qV9az8ybeCMLOAgkrktinx7O5vlmk/0z0c4P8YjW/bxMwPvkytuRlWG5zNQd4IRYMEq7Gr9k3rQVA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/caip/-/caip-1.0.0.tgz",
+      "integrity": "sha512-+U9P7+9jeVBWoP7BDWHVD/JGp9azT4KmFCpDRKTy0U01bCV0x7bxwf6WTl0/dUnnTE+ZA9M4EavptQdHg7k1vA=="
     },
     "call-bind": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@ceramicnetwork/common": "^1.1.0",
     "@ceramicnetwork/stream-caip10-link": "^1.0.7",
     "bignumber.js": "^9.0.1",
-    "caip": "1.0.0-beta.0",
+    "caip": "^1.0.0",
     "cross-fetch": "^3.1.4",
     "json-to-graphql-query": "^2.1.0",
     "merge-options": "^3.0.4",


### PR DESCRIPTION
`caip` library v1.0.0 is just released. Let's use that.